### PR TITLE
Add ability to build scudo-free 32-bit libc variant.

### DIFF
--- a/libc/Android.bp
+++ b/libc/Android.bp
@@ -119,15 +119,32 @@ cc_defaults {
     // warning since this is intended right now.
     ldflags: ["-Wl,-z,muldefs"],
 
-    product_variables: {
-        malloc_zero_contents: {
-            cflags: ["-DSCUDO_ZERO_CONTENTS"],
+    multilib: {
+        lib64: {
+            product_variables: {
+                malloc_zero_contents: {
+                    cflags: ["-DSCUDO_ZERO_CONTENTS"],
+                },
+                malloc_pattern_fill_contents: {
+                    cflags: ["-DSCUDO_PATTERN_FILL_CONTENTS"],
+                },
+                malloc_not_svelte: {
+                    cflags: ["-DUSE_SCUDO"],
+                },
+            },
         },
-        malloc_pattern_fill_contents: {
-            cflags: ["-DSCUDO_PATTERN_FILL_CONTENTS"],
-        },
-        malloc_not_svelte: {
-            cflags: ["-DUSE_SCUDO"],
+        lib32: {
+            product_variables: {
+                malloc_zero_contents: {
+                    cflags: ["-DSCUDO_ZERO_CONTENTS"],
+                },
+                malloc_pattern_fill_contents: {
+                    cflags: ["-DSCUDO_PATTERN_FILL_CONTENTS"],
+                },
+                malloc_not_svelte_libc32: {
+                    cflags: ["-DUSE_SCUDO"],
+                },
+            },
         },
     },
 }
@@ -143,6 +160,18 @@ libc_scudo_product_variables = {
     },
 }
 
+libc32_scudo_product_variables = {
+    malloc_not_svelte_libc32: {
+        cflags: ["-DUSE_SCUDO"],
+        whole_static_libs: ["libscudo"],
+        exclude_static_libs: [
+            "libjemalloc5",
+            "libc_jemalloc_wrapper",
+        ],
+    },
+}
+
+
 // Defaults for native allocator libs/includes to make it
 // easier to change.
 // To disable scudo for the non-svelte config remove the line:
@@ -157,7 +186,14 @@ cc_defaults {
         "libc_jemalloc_wrapper",
     ],
     header_libs: ["gwp_asan_headers"],
-    product_variables: libc_scudo_product_variables,
+    multilib: {
+        lib64: {
+            product_variables: libc_scudo_product_variables,
+        },
+        lib32: {
+            product_variables: libc32_scudo_product_variables,
+        }
+    },
 }
 
 // Functions not implemented by jemalloc directly, or that need to


### PR DESCRIPTION
Add ability to build scudo-free 32-bit libc variant.

Scudo seems to have issues with camera blobs,
which also the case with google devices.
https://android-review.googlesource.com/q/topic:%22disable-camera24-memory-mitigations%22+(status:open%20OR%20status:merged)
These changes are applied upstream and needed much more
commits in various components which makes it difficult to backport.

Therefore add option to disable scudo only for 32 bit components,
like camera modules.

Change-Id: Ie4e62477b0801413827007c511e547b12ea2f46d